### PR TITLE
feat: Presto's read only system access control

### DIFF
--- a/coordinator/presto/etc/access-control.properties
+++ b/coordinator/presto/etc/access-control.properties
@@ -1,0 +1,1 @@
+access-control.name=read-only


### PR DESCRIPTION
Under this plugin, you are allowed to execute any operation that reads data or metadata, such as `SELECT` or `SHOW`. Setting system level or catalog level session properties is also permitted. However, any operation that writes data or metadata, such as `CREATE`, `INSERT` or `DELETE`, is prohibited.